### PR TITLE
Add multi-page Apple-themed site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Apple Fans Site
+
+Un site web simple en HTML, CSS et JavaScript dédié à l'univers Apple. Il comporte trois pages :
+
+- **Accueil** (`index.html`) : présentation générale.
+- **Produits** (`products.html`) : liste de produits emblématiques.
+- **IA** (`ai.html`) : page de discussion avec un assistant IA utilisant l'API OpenAI (clé à fournir).
+
+Pour utiliser l'IA, ajoutez votre clé API dans `js/script.js` à la place de `YOUR_API_KEY`.

--- a/ai.html
+++ b/ai.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Apple Fans - IA</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <h1>Apple Fans</h1>
+    <nav>
+      <ul>
+        <li><a href="index.html">Accueil</a></li>
+        <li><a href="products.html">Produits</a></li>
+        <li><a href="ai.html">IA</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <h2>Discutez avec notre assistant IA</h2>
+    <div id="chat-container">
+      <div id="messages"></div>
+      <form id="chat-form">
+        <input type="text" id="user-input" placeholder="Posez votre question..." required />
+        <button type="submit">Envoyer</button>
+      </form>
+    </div>
+  </main>
+
+  <footer>
+    <p>&copy; 2024 Apple Fans</p>
+  </footer>
+
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,67 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f5f5f5;
+  color: #333;
+}
+
+header {
+  background-color: #000;
+  color: #fff;
+  padding: 1rem;
+}
+
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+.hero {
+  background-color: #e0e0e0;
+  padding: 2rem;
+  text-align: center;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background-color: #000;
+  color: #fff;
+}
+
+#chat-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+#messages {
+  border: 1px solid #ccc;
+  height: 300px;
+  padding: 1rem;
+  overflow-y: auto;
+  background-color: #fff;
+}
+
+#chat-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+#user-input {
+  flex: 1;
+  padding: 0.5rem;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Apple Fans - Accueil</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <h1>Apple Fans</h1>
+    <nav>
+      <ul>
+        <li><a href="index.html">Accueil</a></li>
+        <li><a href="products.html">Produits</a></li>
+        <li><a href="ai.html">IA</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero">
+      <h2>Bienvenue sur notre site dédié à Apple</h2>
+      <p>Découvrez l'univers de la marque à la pomme, ses nouveautés et ses produits emblématiques.</p>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; 2024 Apple Fans</p>
+  </footer>
+</body>
+</html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,41 @@
+// Simple chat logic to call an AI API (e.g., OpenAI). Replace YOUR_API_KEY with a valid key.
+const form = document.getElementById('chat-form');
+const messages = document.getElementById('messages');
+const userInput = document.getElementById('user-input');
+
+async function sendMessage(text) {
+  const userDiv = document.createElement('div');
+  userDiv.textContent = `Vous: ${text}`;
+  messages.appendChild(userDiv);
+
+  const responseDiv = document.createElement('div');
+  responseDiv.textContent = 'IA: ...';
+  messages.appendChild(responseDiv);
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer YOUR_API_KEY'
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: text }]
+      })
+    });
+    const data = await response.json();
+    const aiText = data.choices?.[0]?.message?.content || 'Erreur de réponse';
+    responseDiv.textContent = `IA: ${aiText}`;
+  } catch (err) {
+    responseDiv.textContent = 'Erreur lors de la connexion à l\'IA';
+  }
+}
+
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const text = userInput.value.trim();
+  if (!text) return;
+  userInput.value = '';
+  sendMessage(text);
+});

--- a/products.html
+++ b/products.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Apple Fans - Produits</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <h1>Apple Fans</h1>
+    <nav>
+      <ul>
+        <li><a href="index.html">Accueil</a></li>
+        <li><a href="products.html">Produits</a></li>
+        <li><a href="ai.html">IA</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <h2>Nos produits préférés</h2>
+    <ul class="products">
+      <li>iPhone 15 Pro</li>
+      <li>MacBook Air M2</li>
+      <li>Apple Watch Ultra</li>
+    </ul>
+  </main>
+
+  <footer>
+    <p>&copy; 2024 Apple Fans</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build `index.html`, `products.html`, and `ai.html` pages
- implement modern layout in `css/style.css`
- add simple chat logic for the AI page in `js/script.js`
- document how to use the site in `README.md`

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_684c85b967c0832d859443aae6de29cc

## Résumé par Sourcery

Ajout d'un site web statique multi-pages sur le thème d'Apple avec une page d'accueil, des pages de produits et de chat IA ; implémentation d'une logique de chat côté client pour les interactions avec l'IA ; et documentation des instructions d'utilisation.

Nouvelles fonctionnalités :
- Ajout d'une page d'accueil, d'une page de produits et d'une page de chat IA avec navigation sur le site

Améliorations :
- Application d'une mise en page et d'un style modernes sur le thème d'Apple via CSS

Documentation :
- Documentation de la structure du site et de l'utilisation de l'API d'IA dans README.md

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a static multi-page Apple-themed website with homepage, products, and AI chat pages; implement client-side chat logic for AI interactions; and document usage instructions.

New Features:
- Add homepage, products page, and AI chat page with site navigation

Enhancements:
- Apply a modern, Apple-themed layout and styling via CSS

Documentation:
- Document site structure and AI API usage in README.md

</details>