### PR TITLE
Use Gemini API

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,7 +1,11 @@
-// Simple chat logic to call an AI API (e.g., OpenAI). Replace YOUR_API_KEY with a valid key.
+// Simple chat logic using the Google Gemini API. Replace YOUR_GEMINI_API_KEY
+// with your actual key.
 const form = document.getElementById('chat-form');
 const messages = document.getElementById('messages');
 const userInput = document.getElementById('user-input');
+
+const GEMINI_API_KEY = 'YOUR_GEMINI_API_KEY';
+const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent';
 
 async function sendMessage(text) {
   const userDiv = document.createElement('div');
@@ -13,19 +17,17 @@ async function sendMessage(text) {
   messages.appendChild(responseDiv);
 
   try {
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetch(`${GEMINI_API_URL}?key=${GEMINI_API_KEY}`, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer YOUR_API_KEY'
+        'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
-        messages: [{ role: 'user', content: text }]
+        contents: [{ parts: [{ text }] }]
       })
     });
     const data = await response.json();
-    const aiText = data.choices?.[0]?.message?.content || 'Erreur de réponse';
+    const aiText = data.candidates?.[0]?.content?.parts?.[0]?.text || 'Erreur de réponse';
     responseDiv.textContent = `IA: ${aiText}`;
   } catch (err) {
     responseDiv.textContent = 'Erreur lors de la connexion à l\'IA';


### PR DESCRIPTION
## Summary
- update JS chat code to call the Gemini API instead of OpenAI

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684c8be6de40832dba9dcb7b112497e0

## Résumé par Sourcery

Remplace les complétions de chat OpenAI par des appels à l'API Google Gemini et adapte la gestion des requêtes/réponses en conséquence.

Nouvelles fonctionnalités :
- Intégration de l'API Google Gemini pour les complétions de chat.

Améliorations :
- Mise à jour du point de terminaison de l'API, de la gestion des clés, du format de la charge utile de la requête et de l'analyse de la réponse pour correspondre aux spécifications de Gemini.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace OpenAI chat completions with Google Gemini API calls and adapt request/response handling accordingly.

New Features:
- Integrate Google Gemini API for chat completions.

Enhancements:
- Update API endpoint, key handling, request payload format, and response parsing to match Gemini specifications.

</details>